### PR TITLE
WIP: Fix/networking

### DIFF
--- a/newlib/libc/sys/hermit/Makefile.am
+++ b/newlib/libc/sys/hermit/Makefile.am
@@ -4,7 +4,7 @@ AM_CCASFLAGS = $(INCLUDES)
  
 noinst_LIBRARIES = lib.a
 
-lib_a_SOURCES = chown.c clock_getres.c clock_gettime.c clock_nanosleep.c clock_settime.c close.c environ.c errno.c execve.c _exit.c fork.c fstat.c getpagesize.c getpid.c gettod.c isatty.c kill.c link.c lseek.c nanosleep.c open.c read.c readlink.c sbrk.c sched.c setitimer.c signal.c stat.c symlink.c sysconf.c times.c unlink.c wait.c write.c context.S makecontext.c inet_ntoa.c
+lib_a_SOURCES = chown.c clock_getres.c clock_gettime.c clock_nanosleep.c clock_settime.c close.c environ.c errno.c execve.c _exit.c fork.c fstat.c getpagesize.c getpid.c gettod.c isatty.c kill.c link.c lseek.c nanosleep.c open.c read.c readlink.c sbrk.c sched.c setitimer.c signal.c stat.c symlink.c sysconf.c times.c unlink.c wait.c write.c context.S makecontext.c inet_ntoa.c inet_pton.c
 lib_a_CCASFLAGS = $(AM_CCASFLAGS)
 lib_a_CFLAGS = $(AM_CFLAGS)
  
@@ -17,4 +17,12 @@ install-data-local:
 	$(mkinstalldirs) $(DESTDIR)$(tooldir)/include/netinet; \
         for i in $(srcdir)/include/netinet/*.h; do \
           $(INSTALL_DATA) $$i $(DESTDIR)$(tooldir)/include/netinet/`basename $$i`; \
-        done;
+        done; \
+  $(mkinstalldirs) $(DESTDIR)$(tooldir)/include/arpa; \
+        for i in $(srcdir)/include/arpa/*.h; do \
+          $(INSTALL_DATA) $$i $(DESTDIR)$(tooldir)/include/arpa/`basename $$i`; \
+        done; \
+  $(mkinstalldirs) $(DESTDIR)$(tooldir)/include/net; \
+        for i in $(srcdir)/include/net/*.h; do \
+          $(INSTALL_DATA) $$i $(DESTDIR)$(tooldir)/include/net/`basename $$i`; \
+        done; \

--- a/newlib/libc/sys/hermit/Makefile.in
+++ b/newlib/libc/sys/hermit/Makefile.in
@@ -87,7 +87,7 @@ am_lib_a_OBJECTS = lib_a-chown.$(OBJEXT) lib_a-clock_getres.$(OBJEXT) \
 	lib_a-times.$(OBJEXT) lib_a-unlink.$(OBJEXT) \
 	lib_a-wait.$(OBJEXT) lib_a-write.$(OBJEXT) \
 	lib_a-makecontext.$(OBJEXT) lib_a-context.$(OBJEXT) \
-	inet_ntoa.$(OBJEXT)
+	lib_a-inet_ntoa.$(OBJEXT) lib_a-inet_pton.$(OBJEXT) 
 lib_a_OBJECTS = $(am_lib_a_OBJECTS)
 DEFAULT_INCLUDES = -I.@am__isrc@
 depcomp =
@@ -211,7 +211,7 @@ AUTOMAKE_OPTIONS = cygnus
 INCLUDES = $(NEWLIB_CFLAGS) $(CROSS_CFLAGS) $(TARGET_CFLAGS)
 AM_CCASFLAGS = $(INCLUDES)
 noinst_LIBRARIES = lib.a
-lib_a_SOURCES = chown.c clock_getres.c clock_gettime.c clock_nanosleep.c clock_settime.c close.c environ.c errno.c execve.c _exit.c fork.c fstat.c getpagesize.c getpid.c gettod.c isatty.c kill.c link.c lseek.c nanosleep.c open.c read.c readlink.c sbrk.c sched.c setitimer.c signal.c stat.c symlink.c sysconf.c times.c unlink.c wait.c write.c context.S makecontext.c inet_ntoa.c
+lib_a_SOURCES = chown.c clock_getres.c clock_gettime.c clock_nanosleep.c clock_settime.c close.c environ.c errno.c execve.c _exit.c fork.c fstat.c getpagesize.c getpid.c gettod.c isatty.c kill.c link.c lseek.c nanosleep.c open.c read.c readlink.c sbrk.c sched.c setitimer.c signal.c stat.c symlink.c sysconf.c times.c unlink.c wait.c write.c context.S makecontext.c inet_ntoa.c inet_pton.c
 lib_a_CCASFLAGS = $(AM_CCASFLAGS)
 lib_a_CFLAGS = $(AM_CFLAGS)
 ACLOCAL_AMFLAGS = -I ../../..
@@ -496,6 +496,12 @@ lib_a-inet_ntoa.o: inet_ntoa.c
 lib_a-inet_ntoa.obj: inet_ntoa.c
 	$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CFLAGS) $(CFLAGS) -c -o lib_a-inet_ntoa.obj `if test -f 'inet_ntoa.c'; then $(CYGPATH_W) 'inet_ntoa.c'; else $(CYGPATH_W) '$(srcdir)/inet_ntoa.c'; fi`
 
+lib_a-inet_pton.o: inet_pton.c
+	$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CFLAGS) $(CFLAGS) -c -o lib_a-inet_pton.o `test -f 'inet_pton.c' || echo '$(srcdir)/'`inet_pton.c
+
+lib_a-inet_pton.obj: inet_pton.c
+	$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CFLAGS) $(CFLAGS) -c -o lib_a-inet_pton.obj `if test -f 'inet_pton.c'; then $(CYGPATH_W) 'inet_pton.c'; else $(CYGPATH_W) '$(srcdir)/inet_pton.c'; fi`
+
 ID: $(HEADERS) $(SOURCES) $(LISP) $(TAGS_FILES)
 	list='$(SOURCES) $(HEADERS) $(LISP) $(TAGS_FILES)'; \
 	unique=`for i in $$list; do \
@@ -673,6 +679,14 @@ install-data-local:
 	$(mkinstalldirs) $(DESTDIR)$(tooldir)/include/netinet; \
         for i in $(srcdir)/include/netinet/*.h; do \
           $(INSTALL_DATA) $$i $(DESTDIR)$(tooldir)/include/netinet/`basename $$i`; \
+        done; \
+	$(mkinstalldirs) $(DESTDIR)$(tooldir)/include/arpa; \
+        for i in $(srcdir)/include/arpa/*.h; do \
+          $(INSTALL_DATA) $$i $(DESTDIR)$(tooldir)/include/arpa/`basename $$i`; \
+        done; \
+	$(mkinstalldirs) $(DESTDIR)$(tooldir)/include/net; \
+        for i in $(srcdir)/include/net/*.h; do \
+          $(INSTALL_DATA) $$i $(DESTDIR)$(tooldir)/include/net/`basename $$i`; \
         done; \
 
 # Tell versions [3.59,3.63) of GNU make to not export all variables.

--- a/newlib/libc/sys/hermit/include/arpa/inet.h
+++ b/newlib/libc/sys/hermit/include/arpa/inet.h
@@ -1,0 +1,2 @@
+/* This file currently only includes in.h since we do not have proper interfaces right now. */
+#include <netinet/in.h>

--- a/newlib/libc/sys/hermit/include/arpa/nameser.h
+++ b/newlib/libc/sys/hermit/include/arpa/nameser.h
@@ -1,0 +1,369 @@
+/*	$OpenBSD: nameser.h,v 1.15 2022/12/27 07:44:56 jmc Exp $	*/
+
+/*
+ * ++Copyright++ 1983, 1989, 1993
+ * -
+ * Copyright (c) 1983, 1989, 1993
+ *    The Regents of the University of California.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ * -
+ * Portions Copyright (c) 1993 by Digital Equipment Corporation.
+ * 
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies, and that
+ * the name of Digital Equipment Corporation not be used in advertising or
+ * publicity pertaining to distribution of the document or software without
+ * specific, written prior permission.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS" AND DIGITAL EQUIPMENT CORP. DISCLAIMS ALL
+ * WARRANTIES WITH REGARD TO THIS SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS.   IN NO EVENT SHALL DIGITAL EQUIPMENT
+ * CORPORATION BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL
+ * DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR
+ * PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
+ * ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS
+ * SOFTWARE.
+ * -
+ * Portions Copyright (c) 1995 by International Business Machines, Inc.
+ *
+ * International Business Machines, Inc. (hereinafter called IBM) grants
+ * permission under its copyrights to use, copy, modify, and distribute this
+ * Software with or without fee, provided that the above copyright notice and
+ * all paragraphs of this notice appear in all copies, and that the name of IBM
+ * not be used in connection with the marketing of any product incorporating
+ * the Software or modifications thereof, without specific, written prior
+ * permission.
+ *
+ * To the extent it has a right to do so, IBM grants an immunity from suit
+ * under its patents, if any, for the use, sale or manufacture of products to
+ * the extent that such products are used for performing Domain Name System
+ * dynamic updates in TCP/IP networks by means of the Software.  No immunity is
+ * granted for any product per se or for any other function of any product.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", AND IBM DISCLAIMS ALL WARRANTIES,
+ * INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE.  IN NO EVENT SHALL IBM BE LIABLE FOR ANY SPECIAL,
+ * DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER ARISING
+ * OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE, EVEN
+ * IF IBM IS APPRISED OF THE POSSIBILITY OF SUCH DAMAGES.
+ * --Copyright--
+ */
+
+/*
+ *      @(#)nameser.h	8.1 (Berkeley) 6/2/93
+ *	$From: nameser.h,v 8.11 1996/10/08 04:51:02 vixie Exp $
+ */
+
+#ifndef _NAMESER_H_
+#define _NAMESER_H_
+
+#include <sys/types.h>
+
+/*
+ * revision information.  this is the release date in YYYYMMDD format.
+ * it can change every day so the right thing to do with it is use it
+ * in preprocessor commands such as "#if (__BIND > 19931104)".  do not
+ * compare for equality; rather, use it to determine whether your resolver
+ * is new enough to contain a certain feature.
+ */
+
+#define __BIND		19960801	/* interface version stamp */
+
+/*
+ * Define constants based on rfc883
+ */
+#define PACKETSZ	512		/* maximum packet size */
+#define MAXDNAME	1025		/* maximum presentation domain name */
+#define MAXCDNAME	255		/* maximum compressed domain name */
+#define MAXLABEL	63		/* maximum length of domain label */
+#define HFIXEDSZ	12		/* #/bytes of fixed data in header */
+#define QFIXEDSZ	4		/* #/bytes of fixed data in query */
+#define RRFIXEDSZ	10		/* #/bytes of fixed data in r record */
+#define INT32SZ		4		/* for systems without 32-bit ints */
+#define INT16SZ		2		/* for systems without 16-bit ints */
+#define INADDRSZ	4		/* IPv4 T_A */
+#define IN6ADDRSZ	16		/* IPv6 T_AAAA */
+
+/*
+ * Internet nameserver port number
+ */
+#define NAMESERVER_PORT	53
+
+/*
+ * Currently defined opcodes
+ */
+#define QUERY		0x0		/* standard query */
+#define IQUERY		0x1		/* inverse query */
+#define STATUS		0x2		/* nameserver status query */
+/*#define xxx		0x3*/		/* 0x3 reserved */
+#define NS_NOTIFY_OP	0x4		/* notify secondary of SOA change */
+/*
+ * Currently defined response codes
+ */
+#define NOERROR		0		/* no error */
+#define FORMERR		1		/* format error */
+#define SERVFAIL	2		/* server failure */
+#define NXDOMAIN	3		/* non existent domain */
+#define NOTIMP		4		/* not implemented */
+#define REFUSED		5		/* query refused */
+
+/*
+ * Type values for resources and queries
+ */
+#define T_A		1		/* host address */
+#define T_NS		2		/* authoritative server */
+#define T_MD		3		/* mail destination */
+#define T_MF		4		/* mail forwarder */
+#define T_CNAME		5		/* canonical name */
+#define T_SOA		6		/* start of authority zone */
+#define T_MB		7		/* mailbox domain name */
+#define T_MG		8		/* mail group member */
+#define T_MR		9		/* mail rename name */
+#define T_NULL		10		/* null resource record */
+#define T_WKS		11		/* well known service */
+#define T_PTR		12		/* domain name pointer */
+#define T_HINFO		13		/* host information */
+#define T_MINFO		14		/* mailbox information */
+#define T_MX		15		/* mail routing information */
+#define T_TXT		16		/* text strings */
+#define T_RP		17		/* responsible person */
+#define T_AFSDB		18		/* AFS cell database */
+#define T_X25		19		/* X_25 calling address */
+#define T_ISDN		20		/* ISDN calling address */
+#define T_RT		21		/* router */
+#define T_NSAP		22		/* NSAP address */
+#define T_NSAP_PTR	23		/* reverse NSAP lookup (deprecated) */
+#define T_SIG		24		/* security signature */
+#define T_KEY		25		/* security key */
+#define T_PX		26		/* X.400 mail mapping */
+#define T_GPOS		27		/* geographical position (withdrawn) */
+#define T_AAAA		28		/* IP6 Address */
+#define T_LOC		29		/* Location Information */
+#define T_NXT		30		/* Next Valid Name in Zone */
+#define T_EID		31		/* Endpoint identifier */
+#define T_NIMLOC	32		/* Nimrod locator */
+#define T_SRV		33		/* Server selection */
+#define T_ATMA		34		/* ATM Address */
+#define T_NAPTR		35		/* Naming Authority PoinTeR */
+#define T_KX		36		/* Key Exchanger */
+#define T_CERT		37		/* CERT */
+#define T_A6		38		/* A6 */
+#define T_DNAME		39		/* DNAME */
+#define T_SINK		40		/* SINK */
+#define T_OPT		41		/* OPT pseudo-RR, RFC2671 */
+#define T_APL		42		/* APL */
+#define T_DS		43		/* Delegation Signer */
+#define T_SSHFP		44		/* SSH Key Fingerprint */
+#define T_RRSIG		46		/* RRSIG */
+#define T_NSEC		47		/* NSEC */
+#define T_DNSKEY	48		/* DNSKEY */
+	/* non standard */
+#define T_UINFO		100		/* user (finger) information */
+#define T_UID		101		/* user ID */
+#define T_GID		102		/* group ID */
+#define T_UNSPEC	103		/* Unspecified format (binary data) */
+	/* Query type values which do not appear in resource records */
+#define	T_TKEY		249		/* Transaction Key */
+#define	T_TSIG		250		/* Transaction Signature */
+#define	T_IXFR		251		/* incremental zone transfer */
+#define T_AXFR		252		/* transfer zone of authority */
+#define T_MAILB		253		/* transfer mailbox records */
+#define T_MAILA		254		/* transfer mail agent records */
+#define T_ANY		255		/* wildcard match */
+
+/*
+ * Values for class field
+ */
+
+#define C_IN		1		/* the arpa internet */
+#define C_CHAOS		3		/* for chaos net (MIT) */
+#define C_HS		4		/* for Hesiod name server (MIT) (XXX) */
+	/* Query class values which do not appear in resource records */
+#define C_ANY		255		/* wildcard match */
+
+/*
+ * Flags field of the KEY RR rdata
+ */
+#define	KEYFLAG_TYPEMASK	0xC000	/* Mask for "type" bits */
+#define	KEYFLAG_TYPE_AUTH_CONF	0x0000	/* Key usable for both */
+#define	KEYFLAG_TYPE_CONF_ONLY	0x8000	/* Key usable for confidentiality */
+#define	KEYFLAG_TYPE_AUTH_ONLY	0x4000	/* Key usable for authentication */
+#define	KEYFLAG_TYPE_NO_KEY	0xC000	/* No key usable for either; no key */
+/* The type bits can also be interpreted independently, as single bits: */
+#define	KEYFLAG_NO_AUTH		0x8000	/* Key not usable for authentication */
+#define	KEYFLAG_NO_CONF		0x4000	/* Key not usable for confidentiality */
+
+#define	KEYFLAG_EXPERIMENTAL	0x2000	/* Security is *mandatory* if bit=0 */
+#define	KEYFLAG_RESERVED3	0x1000  /* reserved - must be zero */
+#define	KEYFLAG_RESERVED4	0x0800  /* reserved - must be zero */
+#define	KEYFLAG_USERACCOUNT	0x0400	/* key is assoc. with a user acct */
+#define	KEYFLAG_ENTITY		0x0200	/* key is assoc. with entity eg host */
+#define	KEYFLAG_ZONEKEY		0x0100	/* key is zone key for the zone named */
+#define	KEYFLAG_IPSEC		0x0080  /* key is for IPsec use (host or user)*/
+#define	KEYFLAG_EMAIL		0x0040  /* key is for email (MIME security) */
+#define	KEYFLAG_RESERVED10	0x0020  /* reserved - must be zero */
+#define	KEYFLAG_RESERVED11	0x0010  /* reserved - must be zero */
+#define	KEYFLAG_SIGNATORYMASK	0x000F	/* key can sign DNS RR's of same name */
+
+#define  KEYFLAG_RESERVED_BITMASK ( KEYFLAG_RESERVED3 | \
+				    KEYFLAG_RESERVED4 | \
+				    KEYFLAG_RESERVED10| KEYFLAG_RESERVED11) 
+
+/* The Algorithm field of the KEY and SIG RR's is an integer, {1..254} */
+#define	ALGORITHM_MD5RSA	1	/* MD5 with RSA */
+#define	ALGORITHM_EXPIRE_ONLY	253	/* No alg, no security */
+#define	ALGORITHM_PRIVATE_OID	254	/* Key begins with OID indicating alg */
+
+/* Signatures */
+					/* Size of a mod or exp in bits */
+#define	MIN_MD5RSA_KEY_PART_BITS	 512
+#define	MAX_MD5RSA_KEY_PART_BITS	2552
+					/* Total of binary mod and exp, bytes */
+#define	MAX_MD5RSA_KEY_BYTES		((MAX_MD5RSA_KEY_PART_BITS+7/8)*2+3)
+					/* Max length of text sig block */
+#define	MAX_KEY_BASE64			(((MAX_MD5RSA_KEY_BYTES+2)/3)*4)
+
+/*
+ * EDNS0 Z-field extended flags
+ */
+#define DNS_MESSAGEEXTFLAG_DO	0x8000U
+
+/*
+ * Status return codes for T_UNSPEC conversion routines
+ */
+#define CONV_SUCCESS	0
+#define CONV_OVERFLOW	(-1)
+#define CONV_BADFMT	(-2)
+#define CONV_BADCKSUM	(-3)
+#define CONV_BADBUFLEN	(-4)
+
+#if !defined(_BYTE_ORDER) || \
+    (_BYTE_ORDER != _BIG_ENDIAN && _BYTE_ORDER != _LITTLE_ENDIAN && \
+    _BYTE_ORDER != _PDP_ENDIAN)
+	/* you must determine what the correct bit order is for
+	 * your compiler - the next line is an intentional error
+	 * which will force your compiles to bomb until you fix
+	 * the above macros.
+	 */
+#error "Undefined or invalid _BYTE_ORDER";
+#endif
+
+/*
+ * Structure for query header.  The order of the fields is machine- and
+ * compiler-dependent, depending on the byte/bit order and the layout
+ * of bit fields.  We use bit fields only in int variables, as this
+ * is all ANSI requires.  This requires a somewhat confusing rearrangement.
+ */
+
+typedef struct {
+	unsigned	id :16;		/* query identification number */
+#if _BYTE_ORDER == _BIG_ENDIAN
+			/* fields in third byte */
+	unsigned	qr: 1;		/* response flag */
+	unsigned	opcode: 4;	/* purpose of message */
+	unsigned	aa: 1;		/* authoritative answer */
+	unsigned	tc: 1;		/* truncated message */
+	unsigned	rd: 1;		/* recursion desired */
+			/* fields in fourth byte */
+	unsigned	ra: 1;		/* recursion available */
+	unsigned	unused :1;	/* unused bits (MBZ as of 4.9.3a3) */
+	unsigned	ad: 1;		/* authentic data from named */
+	unsigned	cd: 1;		/* checking disabled by resolver */
+	unsigned	rcode :4;	/* response code */
+#endif
+#if _BYTE_ORDER == _LITTLE_ENDIAN || _BYTE_ORDER == _PDP_ENDIAN
+			/* fields in third byte */
+	unsigned	rd :1;		/* recursion desired */
+	unsigned	tc :1;		/* truncated message */
+	unsigned	aa :1;		/* authoritative answer */
+	unsigned	opcode :4;	/* purpose of message */
+	unsigned	qr :1;		/* response flag */
+			/* fields in fourth byte */
+	unsigned	rcode :4;	/* response code */
+	unsigned	cd: 1;		/* checking disabled by resolver */
+	unsigned	ad: 1;		/* authentic data from named */
+	unsigned	unused :1;	/* unused bits (MBZ as of 4.9.3a3) */
+	unsigned	ra :1;		/* recursion available */
+#endif
+			/* remaining bytes */
+	unsigned	qdcount :16;	/* number of question entries */
+	unsigned	ancount :16;	/* number of answer entries */
+	unsigned	nscount :16;	/* number of authority entries */
+	unsigned	arcount :16;	/* number of resource entries */
+} HEADER;
+
+/*
+ * Defines for handling compressed domain names
+ */
+#define INDIR_MASK	0xc0
+
+extern	u_int16_t	_getshort(const unsigned char *);
+extern	u_int32_t	_getlong(const unsigned char *);
+
+/*
+ * Inline versions of get/put short/long.  Pointer is advanced.
+ *
+ * These macros demonstrate the property of C whereby it can be
+ * portable or it can be elegant but rarely both.
+ */
+#define GETSHORT(s, cp) { \
+	unsigned char *t_cp = (unsigned char *)(cp); \
+	(s) = ((u_int16_t)t_cp[0] << 8) \
+	    | ((u_int16_t)t_cp[1]) \
+	    ; \
+	(cp) += INT16SZ; \
+}
+
+#define GETLONG(l, cp) { \
+	unsigned char *t_cp = (unsigned char *)(cp); \
+	(l) = ((u_int32_t)t_cp[0] << 24) \
+	    | ((u_int32_t)t_cp[1] << 16) \
+	    | ((u_int32_t)t_cp[2] << 8) \
+	    | ((u_int32_t)t_cp[3]) \
+	    ; \
+	(cp) += INT32SZ; \
+}
+
+#define PUTSHORT(s, cp) { \
+	u_int16_t t_s = (u_int16_t)(s); \
+	unsigned char *t_cp = (unsigned char *)(cp); \
+	*t_cp++ = t_s >> 8; \
+	*t_cp   = t_s; \
+	(cp) += INT16SZ; \
+}
+
+#define PUTLONG(l, cp) { \
+	u_int32_t t_l = (u_int32_t)(l); \
+	unsigned char *t_cp = (unsigned char *)(cp); \
+	*t_cp++ = t_l >> 24; \
+	*t_cp++ = t_l >> 16; \
+	*t_cp++ = t_l >> 8; \
+	*t_cp   = t_l; \
+	(cp) += INT32SZ; \
+}
+
+#endif /* !_NAMESER_H_ */

--- a/newlib/libc/sys/hermit/include/net/if.h
+++ b/newlib/libc/sys/hermit/include/net/if.h
@@ -1,0 +1,426 @@
+/*
+ * Copyright (c) 2000-2004 Apple Computer, Inc. All rights reserved.
+ *
+ * @APPLE_LICENSE_HEADER_START@
+ * 
+ * The contents of this file constitute Original Code as defined in and
+ * are subject to the Apple Public Source License Version 1.1 (the
+ * "License").  You may not use this file except in compliance with the
+ * License.  Please obtain a copy of the License at
+ * http://www.apple.com/publicsource and read it before using this file.
+ * 
+ * This Original Code and all software distributed under the License are
+ * distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE OR NON-INFRINGEMENT.  Please see the
+ * License for the specific language governing rights and limitations
+ * under the License.
+ * 
+ * @APPLE_LICENSE_HEADER_END@
+ */
+/*
+ * Copyright (c) 1982, 1986, 1989, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)if.h	8.1 (Berkeley) 6/10/93
+ * $FreeBSD: src/sys/net/if.h,v 1.58.2.2 2001/07/24 19:10:18 brooks Exp $
+ */
+
+#ifndef _NET_IF_H_
+#define	_NET_IF_H_
+
+#define	IF_NAMESIZE	16
+
+#ifndef _POSIX_C_SOURCE
+#include <sys/appleapiopts.h>
+#ifdef __APPLE__
+/*
+ * Define Data-Link event subclass, and associated
+ * events.
+ */
+
+#define KEV_DL_SUBCLASS 2
+
+#define KEV_DL_SIFFLAGS	    1
+#define KEV_DL_SIFMETRICS   2
+#define KEV_DL_SIFMTU	    3
+#define KEV_DL_SIFPHYS	    4
+#define KEV_DL_SIFMEDIA	    5
+#define KEV_DL_SIFGENERIC   6
+#define KEV_DL_ADDMULTI	    7
+#define KEV_DL_DELMULTI	    8
+#define KEV_DL_IF_ATTACHED  9
+#define KEV_DL_IF_DETACHING 10
+#define KEV_DL_IF_DETACHED  11
+#define KEV_DL_LINK_OFF	    12
+#define KEV_DL_LINK_ON	    13
+#define KEV_DL_PROTO_ATTACHED	14
+#define KEV_DL_PROTO_DETACHED	15
+#define KEV_DL_LINK_ADDRESS_CHANGED	16
+
+#include <net/if_var.h>
+#include <sys/types.h>
+#endif
+
+#ifdef KERNEL_PRIVATE
+struct if_clonereq {
+	int	ifcr_total;		/* total cloners (out) */
+	int	ifcr_count;		/* room for this many in user buffer */
+	char	*ifcr_buffer;		/* buffer for cloner names */
+};
+
+/* in-kernel, LP64-aware version of if_clonereq.  all pointers 
+ * grow when we're dealing with a 64-bit process.
+ * WARNING - keep in sync with if_clonereq
+ */
+struct if_clonereq64 {
+	int	ifcr_total;		/* total cloners (out) */
+	int	ifcr_count;		/* room for this many in user buffer */
+	union {
+	    u_int64_t	ifcru_buffer64;
+	    char *	ifcru_buffer32;
+	} ifcr_ifcru;
+};
+#endif KERNEL_PRIVATE
+
+#define	IFF_UP		0x1		/* interface is up */
+#define	IFF_BROADCAST	0x2		/* broadcast address valid */
+#define	IFF_DEBUG	0x4		/* turn on debugging */
+#define	IFF_LOOPBACK	0x8		/* is a loopback net */
+#define	IFF_POINTOPOINT	0x10		/* interface is point-to-point link */
+#define IFF_NOTRAILERS 0x20		/* obsolete: avoid use of trailers */
+#define	IFF_RUNNING	0x40		/* resources allocated */
+#define	IFF_NOARP	0x80		/* no address resolution protocol */
+#define	IFF_PROMISC	0x100		/* receive all packets */
+#define	IFF_ALLMULTI	0x200		/* receive all multicast packets */
+#define	IFF_OACTIVE	0x400		/* transmission in progress */
+#define	IFF_SIMPLEX	0x800		/* can't hear own transmissions */
+#define	IFF_LINK0	0x1000		/* per link layer defined bit */
+#define	IFF_LINK1	0x2000		/* per link layer defined bit */
+#define	IFF_LINK2	0x4000		/* per link layer defined bit */
+#define	IFF_ALTPHYS	IFF_LINK2	/* use alternate physical connection */
+#define	IFF_MULTICAST	0x8000		/* supports multicast */
+
+#ifdef KERNEL_PRIVATE
+/* extended flags definitions:  (all bits are reserved for internal/future use) */
+#define IFEF_AUTOCONFIGURING	0x1
+#define IFEF_DVR_REENTRY_OK	0x20	/* When set, driver may be reentered from its own thread */
+#define IFEF_ACCEPT_RTADVD	0x40	/* set to accept IPv6 router advertisement on the interface */
+#define IFEF_DETACHING		0x80	/* Set when interface is detaching */
+#define IFEF_USEKPI			0x100	/* Set when interface is created through the KPIs */
+#define IFEF_VLAN		0x200	/* interface has one or more vlans */
+#define IFEF_BOND		0x400	/* interface is part of bond */
+#define	IFEF_ARPLL		0x800	/* ARP for IPv4LL addresses on this port */
+#define IFEF_REUSE	0x20000000 /* DLIL ifnet recycler, ifnet is not new */
+#define IFEF_INUSE	0x40000000 /* DLIL ifnet recycler, ifnet in use */
+#define IFEF_UPDOWNCHANGE	0x80000000 /* Interface's up/down state is changing */
+
+/* flags set internally only: */
+#define	IFF_CANTCHANGE \
+	(IFF_BROADCAST|IFF_POINTOPOINT|IFF_RUNNING|IFF_OACTIVE|\
+	    IFF_SIMPLEX|IFF_MULTICAST|IFF_ALLMULTI)
+
+#endif /* KERNEL_PRIVATE */
+
+#define	IFQ_MAXLEN	50
+#define	IFNET_SLOWHZ	1		/* granularity is 1 second */
+
+/*
+ * Message format for use in obtaining information about interfaces
+ * from sysctl and the routing socket
+ */
+struct if_msghdr {
+	unsigned short	ifm_msglen;	/* to skip over non-understood messages */
+	unsigned char	ifm_version;	/* future binary compatability */
+	unsigned char	ifm_type;	/* message type */
+	int		ifm_addrs;	/* like rtm_addrs */
+	int		ifm_flags;	/* value of if_flags */
+	unsigned short	ifm_index;	/* index for associated ifp */
+	struct	if_data ifm_data;	/* statistics and other data about if */
+};
+
+/*
+ * Message format for use in obtaining information about interface addresses
+ * from sysctl and the routing socket
+ */
+struct ifa_msghdr {
+	unsigned short	ifam_msglen;	/* to skip over non-understood messages */
+	unsigned char	ifam_version;	/* future binary compatability */
+	unsigned char	ifam_type;	/* message type */
+	int		ifam_addrs;	/* like rtm_addrs */
+	int		ifam_flags;	/* value of ifa_flags */
+	unsigned short	ifam_index;	/* index for associated ifp */
+	int		ifam_metric;	/* value of ifa_metric */
+};
+
+/*
+ * Message format for use in obtaining information about multicast addresses
+ * from the routing socket
+ */
+struct ifma_msghdr {
+	unsigned short	ifmam_msglen;	/* to skip over non-understood messages */
+	unsigned char	ifmam_version;	/* future binary compatability */
+	unsigned char	ifmam_type;	/* message type */
+	int		ifmam_addrs;	/* like rtm_addrs */
+	int		ifmam_flags;	/* value of ifa_flags */
+	unsigned short	ifmam_index;	/* index for associated ifp */
+};
+
+/*
+ * Message format for use in obtaining information about interfaces
+ * from sysctl 
+ */
+struct if_msghdr2 {
+	u_short	ifm_msglen;	/* to skip over non-understood messages */
+	u_char	ifm_version;	/* future binary compatability */
+	u_char	ifm_type;	/* message type */
+	int	ifm_addrs;	/* like rtm_addrs */
+	int	ifm_flags;	/* value of if_flags */
+	u_short	ifm_index;	/* index for associated ifp */
+	int	ifm_snd_len;	/* instantaneous length of send queue */
+	int	ifm_snd_maxlen;	/* maximum length of send queue */
+	int	ifm_snd_drops;	/* number of drops in send queue */
+	int	ifm_timer;	/* time until if_watchdog called */
+	struct if_data64	ifm_data;	/* statistics and other data about if */
+};
+
+/*
+ * Message format for use in obtaining information about multicast addresses
+ * from sysctl
+ */
+struct ifma_msghdr2 {
+	u_short	ifmam_msglen;	/* to skip over non-understood messages */
+	u_char	ifmam_version;	/* future binary compatability */
+	u_char	ifmam_type;	/* message type */
+	int	ifmam_addrs;	/* like rtm_addrs */
+	int	ifmam_flags;	/* value of ifa_flags */
+	u_short	ifmam_index;	/* index for associated ifp */
+	int32_t ifmam_refcount;
+};
+
+/*
+ * ifdevmtu: interface device mtu
+ *    Used with SIOCGIFDEVMTU to get the current mtu in use by the device,
+ *    as well as the minimum and maximum mtu allowed by the device.
+ */
+struct ifdevmtu {
+	int	ifdm_current;
+	int	ifdm_min;
+	int	ifdm_max;
+};
+
+/*
+ * Interface request structure used for socket
+ * ioctl's.  All interface ioctl's must have parameter
+ * definitions which begin with ifr_name.  The
+ * remainder may be interface specific.
+ */
+struct	ifreq {
+#ifndef IFNAMSIZ
+#define	IFNAMSIZ	IF_NAMESIZE
+#endif
+	char	ifr_name[IFNAMSIZ];		/* if name, e.g. "en0" */
+	union {
+		struct	sockaddr ifru_addr;
+		struct	sockaddr ifru_dstaddr;
+		struct	sockaddr ifru_broadaddr;
+		short	ifru_flags;
+		int	ifru_metric;
+		int	ifru_mtu;
+		int	ifru_phys;
+		int	ifru_media;
+		int 	ifru_intval;
+		caddr_t	ifru_data;
+#ifdef KERNEL_PRIVATE
+		u_int64_t ifru_data64;	/* 64-bit ifru_data */
+#endif KERNEL_PRIVATE
+		struct	ifdevmtu ifru_devmtu;
+	} ifr_ifru;
+#define	ifr_addr	ifr_ifru.ifru_addr	/* address */
+#define	ifr_dstaddr	ifr_ifru.ifru_dstaddr	/* other end of p-to-p link */
+#define	ifr_broadaddr	ifr_ifru.ifru_broadaddr	/* broadcast address */
+#ifdef __APPLE__
+#define	ifr_flags	ifr_ifru.ifru_flags	/* flags */
+#else
+#define	ifr_flags	ifr_ifru.ifru_flags[0]	/* flags */
+#define	ifr_prevflags	ifr_ifru.ifru_flags[1]	/* flags */
+#endif /* __APPLE__ */
+#define	ifr_metric	ifr_ifru.ifru_metric	/* metric */
+#define	ifr_mtu		ifr_ifru.ifru_mtu	/* mtu */
+#define ifr_phys	ifr_ifru.ifru_phys	/* physical wire */
+#define ifr_media	ifr_ifru.ifru_media	/* physical media */
+#define	ifr_data	ifr_ifru.ifru_data	/* for use by interface */
+#define ifr_devmtu	ifr_ifru.ifru_devmtu	
+#define ifr_intval	ifr_ifru.ifru_intval	/* integer value */
+#ifdef KERNEL_PRIVATE
+#define ifr_data64	ifr_ifru.ifru_data64	/* 64-bit pointer */
+#endif KERNEL_PRIVATE
+};
+
+#define	_SIZEOF_ADDR_IFREQ(ifr) \
+	((ifr).ifr_addr.sa_len > sizeof(struct sockaddr) ? \
+	 (sizeof(struct ifreq) - sizeof(struct sockaddr) + \
+	  (ifr).ifr_addr.sa_len) : sizeof(struct ifreq))
+
+struct ifaliasreq {
+	char	ifra_name[IFNAMSIZ];		/* if name, e.g. "en0" */
+	struct	sockaddr ifra_addr;
+	struct	sockaddr ifra_broadaddr;
+	struct	sockaddr ifra_mask;
+};
+
+struct rslvmulti_req {
+     struct sockaddr *sa;
+     struct sockaddr **llsa;
+};
+
+struct ifmediareq {
+	char	ifm_name[IFNAMSIZ];	/* if name, e.g. "en0" */
+	int	ifm_current;		/* current media options */
+	int	ifm_mask;		/* don't care mask */
+	int	ifm_status;		/* media status */
+	int	ifm_active;		/* active options */
+	int	ifm_count;		/* # entries in ifm_ulist array */
+	int	*ifm_ulist;		/* media words */
+};
+
+#ifdef KERNEL_PRIVATE
+/* LP64 version of ifmediareq.  all pointers 
+ * grow when we're dealing with a 64-bit process.
+ * WARNING - keep in sync with ifmediareq
+ */
+struct ifmediareq64 {
+	char	ifm_name[IFNAMSIZ];	/* if name, e.g. "en0" */
+	int	ifm_current;		/* current media options */
+	int	ifm_mask;		/* don't care mask */
+	int	ifm_status;		/* media status */
+	int	ifm_active;		/* active options */
+	int	ifm_count;		/* # entries in ifm_ulist array */
+	union {				/* media words */
+	    int * 	ifmu_ulist32;	/* 32-bit pointer */
+	    u_int64_t	ifmu_ulist64;	/* 64-bit pointer */
+	} ifm_ifmu;
+};
+#endif // KERNEL_PRIVATE
+
+/* 
+ * Structure used to retrieve aux status data from interfaces.
+ * Kernel suppliers to this interface should respect the formatting
+ * needed by ifconfig(8): each line starts with a TAB and ends with
+ * a newline.  The canonical example to copy and paste is in if_tun.c.
+ */
+
+#define	IFSTATMAX	800		/* 10 lines of text */
+struct ifstat {
+	char	ifs_name[IFNAMSIZ];	/* if name, e.g. "en0" */
+	char	ascii[IFSTATMAX + 1];
+};
+
+/*
+ * Structure used in SIOCGIFCONF request.
+ * Used to retrieve interface configuration
+ * for machine (useful for programs which
+ * must know all networks accessible).
+ */
+struct	ifconf {
+	int	ifc_len;		/* size of associated buffer */
+	union {
+		caddr_t	ifcu_buf;
+		struct	ifreq *ifcu_req;
+	} ifc_ifcu;
+#define	ifc_buf	ifc_ifcu.ifcu_buf	/* buffer address */
+#define	ifc_req	ifc_ifcu.ifcu_req	/* array of structures returned */
+};
+
+#ifdef KERNEL_PRIVATE
+/* LP64 version of ifconf.  all pointers 
+ * grow when we're dealing with a 64-bit process.
+ * WARNING - keep in sync with ifconf
+ */
+struct ifconf64 {
+	int     ifc_len;		/* size of associated buffer */
+	union {
+		struct ifreq *	ifcu_req;
+	    	u_int64_t	ifcu_req64;
+	} ifc_ifcu;
+};
+#define	ifc_req64	ifc_ifcu.ifcu_req64
+#endif // KERNEL_PRIVATE
+
+/*
+ * DLIL KEV_DL_PROTO_ATTACHED/DETACHED structure
+ */
+struct kev_dl_proto_data {
+     struct net_event_data   	link_data;
+     unsigned long		proto_family;
+     unsigned long		proto_remaining_count;
+};
+
+/*
+ * Structure for SIOC[AGD]LIFADDR
+ */
+struct if_laddrreq {
+	char			iflr_name[IFNAMSIZ];
+	unsigned int		flags;
+#define	IFLR_PREFIX	0x8000  /* in: prefix given  out: kernel fills id */
+	unsigned int		prefixlen;         /* in/out */
+	struct sockaddr_storage	addr;   /* in/out */
+	struct sockaddr_storage	dstaddr; /* out */
+};
+
+#ifdef KERNEL
+#ifdef MALLOC_DECLARE
+MALLOC_DECLARE(M_IFADDR);
+MALLOC_DECLARE(M_IFMADDR);
+#endif
+#endif
+#endif /* _POSIX_C_SOURCE */
+
+#ifndef KERNEL
+struct if_nameindex {
+	unsigned int	 if_index;	/* 1, 2, ... */
+	char		*if_name;	/* null terminated name: "le0", ... */
+};
+
+__BEGIN_DECLS
+unsigned int	 if_nametoindex(const char *);
+char		*if_indextoname(unsigned int, char *);
+struct		 if_nameindex *if_nameindex(void);
+void		 if_freenameindex(struct if_nameindex *);
+__END_DECLS
+#endif
+
+#ifdef KERNEL
+#include <net/kpi_interface.h>
+#endif
+
+#endif /* !_NET_IF_H_ */

--- a/newlib/libc/sys/hermit/include/netdb.h
+++ b/newlib/libc/sys/hermit/include/netdb.h
@@ -26,7 +26,6 @@ struct sockaddr_in {
     short            sin_family;   // e.g. AF_INET
     unsigned short   sin_port;     // e.g. htons(3490)
     struct in_addr   sin_addr;     // see struct in_addr, below
-    char             sin_zero[8];  // zero this if you want to
 };
 
 #ifdef __cplusplus

--- a/newlib/libc/sys/hermit/include/netinet/in.h
+++ b/newlib/libc/sys/hermit/include/netinet/in.h
@@ -38,8 +38,6 @@ uint16_t htons(uint16_t hostshort);
 uint32_t ntohl(uint32_t netlong);
 uint16_t ntohs(uint16_t netshort);
 
-int inet_pton(int af, const char *src, void *dst);
-
 /** 255.255.255.255 */
 #define IPADDR_NONE         ((uint32_t)0xffffffffUL)
 /** 127.0.0.1 */

--- a/newlib/libc/sys/hermit/inet_pton.c
+++ b/newlib/libc/sys/hermit/inet_pton.c
@@ -1,0 +1,290 @@
+/*
+ * Copyright (c) 1996,1999 by Internet Software Consortium.
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND INTERNET SOFTWARE CONSORTIUM DISCLAIMS
+ * ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL INTERNET SOFTWARE
+ * CONSORTIUM BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL
+ * DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR
+ * PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
+ * ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS
+ * SOFTWARE.
+ */
+
+#if defined(LIBC_SCCS) && !defined(lint)
+static char rcsid[] = "$Id: inet_pton.c,v 1.3 2003/04/10 18:53:29 majka Exp $";
+#endif /* LIBC_SCCS and not lint */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <sys/param.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <net/if.h>
+#include <arpa/nameser.h>
+#include <string.h>
+#include <stdlib.h>
+#include <errno.h>
+
+#define IN6ADDRSZ              16
+
+#if 0
+#ifndef HAVE_PORTABLE_PROTOTYPE
+#include "cdecl_ext.h"
+#endif 
+
+#ifndef HAVE_U_INT16_T
+#include "bittypes.h"
+#endif 
+#if !(defined(HAVE_INADDRSZ) && defined(HAVE_IN6ADDRSZ))
+#include "addrsize.h"
+#endif 
+#endif
+#ifndef NS_INADDRSZ
+#define NS_INADDRSZ	INADDRSZ
+#endif
+#ifndef NS_IN6ADDRSZ
+#define NS_IN6ADDRSZ	IN6ADDRSZ
+#endif
+#ifndef NS_INT16SZ
+#define NS_INT16SZ	sizeof(u_int16_t)
+#endif
+
+/*
+ * WARNING: Don't even consider trying to compile this on a system where
+ * sizeof(int) < 4.  sizeof(int) > 4 is fine; all the world's not a VAX.
+ */
+
+static int	inet_pton4 __P((const char *src, u_char *dst));
+#ifdef INET6
+static int	inet_pton6 __P((const char *src, u_char *dst));
+#endif
+
+/* int
+ * inet_pton(af, src, dst)
+ *	convert from presentation format (which usually means ASCII printable)
+ *	to network format (which is usually some kind of binary format).
+ * return:
+ *	1 if the address was valid for the specified address family
+ *	0 if the address wasn't valid (`dst' is untouched in this case)
+ *	-1 if some other error occurred (`dst' is untouched in this case, too)
+ * author:
+ *	Paul Vixie, 1996.
+ */
+int
+inet_pton(int af, const char *src, void *dst)
+{
+	int status;
+	unsigned short ifnum;
+	char *p, *s;
+
+	switch (af)
+	{
+		case AF_INET:
+		{
+			return (inet_pton4(src, dst));
+		}
+
+#ifdef INET6
+		case AF_INET6:
+		{
+			ifnum = 0;
+			p = NULL;
+			s = (char *)src;
+
+			if (src != NULL) p = strrchr(src, '%');
+			if (p != NULL)
+			{
+				s = strdup(src);
+				if (s == NULL)
+				{
+					errno = ENOMEM;
+					return -1;
+				}
+				
+				s[p - src] = '\0';
+			}
+
+			status = inet_pton6(s, dst);
+			if (p != NULL) free(s);
+			if (status != 1) return status;
+			
+			if ((p != NULL) && IN6_IS_ADDR_LINKLOCAL((struct in6_addr *)dst))
+			{
+				ifnum = if_nametoindex(++p);
+				ifnum = htons(ifnum);
+				((struct in6_addr *)dst)->__u6_addr.__u6_addr16[1] = ifnum;
+			}
+
+			return 1;
+		}
+#endif
+
+		default:
+		{
+			errno = EAFNOSUPPORT;
+			return -1;
+		}
+	}
+
+	/* NOTREACHED */
+	return -1;
+}
+
+/* int
+ * inet_pton4(src, dst)
+ *	like inet_aton() but without all the hexadecimal and shorthand.
+ * return:
+ *	1 if `src' is a valid dotted quad, else 0.
+ * notice:
+ *	does not touch `dst' unless it's returning 1.
+ * author:
+ *	Paul Vixie, 1996.
+ */
+static int
+inet_pton4(const char *src, u_char *dst)
+{
+	static const char digits[] = "0123456789";
+	int saw_digit, octets, ch;
+	u_char tmp[NS_INADDRSZ], *tp;
+	
+	saw_digit = 0;
+	octets = 0;
+	*(tp = tmp) = 0;
+	while ((ch = *src++) != '\0') {
+		const char *pch;
+		
+		if ((pch = strchr(digits, ch)) != NULL) {
+			u_int new = *tp * 10 + (pch - digits);
+			
+			if (new > 255)
+				return (0);
+			*tp = new;
+			if (! saw_digit) {
+				if (++octets > 4)
+					return (0);
+				saw_digit = 1;
+			}
+		} else if (ch == '.' && saw_digit) {
+			if (octets == 4)
+				return (0);
+			*++tp = 0;
+			saw_digit = 0;
+		} else
+			return (0);
+	}
+	if (octets < 4)
+		return (0);
+	memcpy(dst, tmp, NS_INADDRSZ);
+	return (1);
+}
+
+#ifdef INET6
+/* int
+ * inet_pton6(src, dst)
+ *	convert presentation level address to network order binary form.
+ * return:
+ *	1 if `src' is a valid [RFC1884 2.2] address, else 0.
+ * notice:
+ *	(1) does not touch `dst' unless it's returning 1.
+ *	(2) :: in a full address is silently ignored.
+ * credit:
+ *	inspired by Mark Andrews.
+ * author:
+ *	Paul Vixie, 1996.
+ */
+static int
+inet_pton6(const char *src, u_char *dst)
+{
+	static const char xdigits_l[] = "0123456789abcdef",
+	xdigits_u[] = "0123456789ABCDEF";
+	u_char tmp[NS_IN6ADDRSZ], *tp, *endp, *colonp;
+	const char *xdigits, *curtok;
+	int ch, saw_xdigit;
+	u_int val;
+	
+	memset((tp = tmp), '\0', NS_IN6ADDRSZ);
+	endp = tp + NS_IN6ADDRSZ;
+	colonp = NULL;
+	/* Leading :: requires some special handling. */
+	if (*src == ':')
+		if (*++src != ':')
+			return (0);
+	curtok = src;
+	saw_xdigit = 0;
+	val = 0;
+	while ((ch = *src++) != '\0') {
+		const char *pch;
+		
+		if ((pch = strchr((xdigits = xdigits_l), ch)) == NULL)
+			pch = strchr((xdigits = xdigits_u), ch);
+		if (pch != NULL) {
+			val <<= 4;
+			val |= (pch - xdigits);
+			if (val > 0xffff)
+				return (0);
+			saw_xdigit = 1;
+			continue;
+		}
+		if (ch == ':') {
+			curtok = src;
+			if (!saw_xdigit) {
+				if (colonp)
+					return (0);
+				colonp = tp;
+				continue;
+			} else if (*src == '\0') {
+				return (0);
+			}
+			if (tp + NS_INT16SZ > endp)
+				return (0);
+			*tp++ = (u_char) (val >> 8) & 0xff;
+			*tp++ = (u_char) val & 0xff;
+			saw_xdigit = 0;
+			val = 0;
+			continue;
+		}
+		if (ch == '.' && ((tp + NS_INADDRSZ) <= endp) &&
+		    inet_pton4(curtok, tp) > 0) {
+			tp += NS_INADDRSZ;
+			saw_xdigit = 0;
+			break;	/* '\0' was seen by inet_pton4(). */
+		}
+		return (0);
+	}
+	if (saw_xdigit) {
+		if (tp + NS_INT16SZ > endp)
+			return (0);
+		*tp++ = (u_char) (val >> 8) & 0xff;
+		*tp++ = (u_char) val & 0xff;
+	}
+	if (colonp != NULL) {
+		/*
+		 * Since some memmove()'s erroneously fail to handle
+		 * overlapping regions, we'll do the shift by hand.
+		 */
+		const int n = tp - colonp;
+		int i;
+		
+		if (tp == endp)
+			return (0);
+		for (i = 1; i <= n; i++) {
+			endp[- i] = colonp[n - i];
+			colonp[n - i] = 0;
+		}
+		tp = endp;
+	}
+	if (tp != endp)
+		return (0);
+	memcpy(dst, tmp, NS_IN6ADDRSZ);
+	return (1);
+}
+#endif /*INET6*/

--- a/newlib/libc/sys/hermit/sys/fcntl.h
+++ b/newlib/libc/sys/hermit/sys/fcntl.h
@@ -80,6 +80,9 @@
 
 /* --- redundant stuff below --- */
 
+#define fcntl           sys_fcntl
+#define _fcntl          fcntl
+
 #include <_ansi.h>
 
 extern int creat (const char*, mode_t);
@@ -94,7 +97,5 @@ extern int fcntl (int, int, ...);
 #endif
 
 extern int _fcntl (int, int, ...);
-
-#define fcntl           sys_fcntl
 
 #endif


### PR DESCRIPTION
This a WIP collection of networking related fixes. 
- Some changes had to be reversed, as they did not work as expected
- inet_pton was added

In the current state hermit-playground can run as a tcp server, with a transfer speed of roughly 100 Mbit/s

What still needs to be done
- arpa/inet.h needs to be restored to it's expected form, this is still an open issue from removing lwip
- inet_pton does not work properly or the sockets can not listen properly
- UDP Ports can not be opened currently

@mkroening this may be of interest for hermit-c, but i do not expect to fix this in the context of my thesis