### PR TITLE
fix(netdb.h): `sockaddr_in` definition

### DIFF
--- a/newlib/libc/sys/hermit/include/netdb.h
+++ b/newlib/libc/sys/hermit/include/netdb.h
@@ -25,10 +25,11 @@ struct in_addr {
 };
 
 struct sockaddr_in {
-    short            sin_family;   // e.g. AF_INET
-    unsigned short   sin_port;     // e.g. htons(3490)
-    struct in_addr   sin_addr;     // see struct in_addr, below
-    char             sin_zero[8];  // zero this if you want to
+    uint8_t sin_len;
+    uint8_t sin_family;
+    uint16_t sin_port;
+    struct in_addr sin_addr;
+    char sin_zero[8];
 };
 
 #ifdef __cplusplus

--- a/newlib/libc/sys/hermit/include/netdb.h
+++ b/newlib/libc/sys/hermit/include/netdb.h
@@ -8,14 +8,14 @@ extern "C" {
 #define socklen_t __socklen_t
 
 typedef struct addrinfo_t {
-  int32_t ai_flags;
-  int32_t ai_family;
-  int32_t ai_socktype;
-  int32_t ai_protocol;
-  socklen_t ai_addrlen;
-  struct sockaddr *ai_addr;
-  uint8_t *ai_canonname;
-  struct addrinfo_t *ai_next;
+    int32_t ai_flags;
+    int32_t ai_family;
+    int32_t ai_socktype;
+    int32_t ai_protocol;
+    socklen_t ai_addrlen;
+    struct sockaddr *ai_addr;
+    uint8_t *ai_canonname;
+    struct addrinfo_t *ai_next;
 } addrinfo;
 
 struct in_addr {

--- a/newlib/libc/sys/hermit/include/netdb.h
+++ b/newlib/libc/sys/hermit/include/netdb.h
@@ -5,6 +5,8 @@
 extern "C" {
 #endif
 
+#include <stdint.h>
+
 #define socklen_t __socklen_t
 
 typedef struct addrinfo_t {
@@ -19,7 +21,7 @@ typedef struct addrinfo_t {
 } addrinfo;
 
 struct in_addr {
-    unsigned long s_addr;  // load with inet_aton()
+    uint32_t s_addr;
 };
 
 struct sockaddr_in {


### PR DESCRIPTION
This fixes things like `connect` calls. The kernel's BSD sockets have always used this layout.

CC: @stlankes, @CarlWachter 