### PR TITLE
fix: stub only `_execve` instead of whole `exec` family

### DIFF
--- a/newlib/libc/sys/hermit/stub-in.c
+++ b/newlib/libc/sys/hermit/stub-in.c
@@ -23,13 +23,7 @@ pid_t wait(int *stat_loc);
 // unistd.h
 
 int chown(const char *path, uid_t owner, gid_t group);
-int execl(const char *path, const char *arg0, ... /*, (char *)0 */);
-int execle(const char *path, const char *arg0, ... /*, (char *)0, char *const envp[]*/);
-int execlp(const char *file, const char *arg0, ... /*, (char *)0 */);
-int execv(const char *path, char *const argv[]);
-int execve(const char *path, char *const argv[], char *const envp[]);
-int execvp(const char *file, char *const argv[]);
-int fexecve(int fd, char *const argv[], char *const envp[]);
+int _execve(const char *path, char *const argv[], char *const envp[]);
 pid_t fork(void);
 int link(const char *path1, const char *path2);
 ssize_t readlink(const char *restrict path, char *restrict buf, size_t bufsize);

--- a/newlib/libc/sys/hermit/stub.c
+++ b/newlib/libc/sys/hermit/stub.c
@@ -42,37 +42,7 @@ int chown(const char *path, uid_t owner, gid_t group) {
     return -1;
 }
 
-int execl(const char *path, const char *arg0, ... /*, (char *)0 */) {
-    errno = ENOSYS;
-    return -1;
-}
-
-int execle(const char *path, const char *arg0, ... /*, (char *)0, char *const envp[]*/) {
-    errno = ENOSYS;
-    return -1;
-}
-
-int execlp(const char *file, const char *arg0, ... /*, (char *)0 */) {
-    errno = ENOSYS;
-    return -1;
-}
-
-int execv(const char *path, char *const argv[]) {
-    errno = ENOSYS;
-    return -1;
-}
-
-int execve(const char *path, char *const argv[], char *const envp[]) {
-    errno = ENOSYS;
-    return -1;
-}
-
-int execvp(const char *file, char *const argv[]) {
-    errno = ENOSYS;
-    return -1;
-}
-
-int fexecve(int fd, char *const argv[], char *const envp[]) {
+int _execve(const char *path, char *const argv[], char *const envp[]) {
     errno = ENOSYS;
     return -1;
 }


### PR DESCRIPTION
The other functions are implemented on top of `_execve` by newlib.