### PR TITLE
fix(time.h): make tv_nsec an int32_t on Hermit

### DIFF
--- a/newlib/libc/include/sys/_timespec.h
+++ b/newlib/libc/include/sys/_timespec.h
@@ -46,7 +46,11 @@ typedef	_TIME_T_	time_t;
 
 struct timespec {
 	time_t	tv_sec;		/* seconds */
+#ifdef __hermit__
+	int32_t	tv_nsec;	/* and nanoseconds */
+#else /* __hermit__ */
 	long	tv_nsec;	/* and nanoseconds */
+#endif /* __hermit__ */
 };
 
 #endif /* !_SYS__TIMESPEC_H_ */


### PR DESCRIPTION
> The <time.h> header shall declare the __timespec__ structure, which shall include at least the following members:
>
> ```
> time_t  tv_sec    Whole seconds.
> long    tv_nsec   Nanoseconds [0, 999999999].
> ```

[(POSIX 2024)](https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/time.h.html)

> The type of `tv_nsec` is an implementation-defined signed integer type that can represent integers in [​`0`​, `999999999`].

[(C23)](https://en.cppreference.com/w/c/chrono/timespec)

The reasons for relaxation are detailed in [N3066](https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3066.pdf). Interesting: `tv_nsec` being a `long` is a holdover from I16L32 architectures. I expect POSIX to follow suit eventually, but the Austin Group has not discussed this yet, as far as I know.

Closes https://github.com/hermit-os/kernel/pull/1778.
Closes https://github.com/hermit-os/hermit-rs/pull/737.