### PR TITLE
fix(timespec.h): include stdint.h on Hermit

### DIFF
--- a/newlib/libc/include/sys/_timespec.h
+++ b/newlib/libc/include/sys/_timespec.h
@@ -38,6 +38,10 @@
 
 #include <sys/_types.h>
 
+#ifdef __hermit__
+#include <stdint.h>
+#endif /* __hermit__ */
+
 #if !defined(__time_t_defined) && !defined(_TIME_T_DECLARED)
 typedef	_TIME_T_	time_t;
 #define	__time_t_defined


### PR DESCRIPTION
This is required for https://github.com/hermit-os/newlib/pull/156.