### PR TITLE
fix: remove sched_setscheduler

### DIFF
--- a/newlib/libc/sys/hermit/stub-in.c
+++ b/newlib/libc/sys/hermit/stub-in.c
@@ -14,7 +14,6 @@
 int sched_getparam(pid_t pid, struct sched_param *param);
 int sched_getscheduler(pid_t pid);
 int sched_setparam(pid_t pid, const struct sched_param *param);
-int sched_setscheduler(pid_t pid, int policy, const struct sched_param *param);
 
 // signal.h
 

--- a/newlib/libc/sys/hermit/stub.c
+++ b/newlib/libc/sys/hermit/stub.c
@@ -29,11 +29,6 @@ int sched_setparam(pid_t pid, const struct sched_param *param) {
     return -1;
 }
 
-int sched_setscheduler(pid_t pid, int policy, const struct sched_param *param) {
-    errno = ENOSYS;
-    return -1;
-}
-
 // signal.h
 
 int kill(pid_t pid, int sig) {


### PR DESCRIPTION
This is provided by pthread-embedded ([sched_setscheduler.c#L47-L52)](https://github.com/hermit-os/pthread-embedded/blob/e376740eacceb5e4ee092fa9a4d1c296bffa2521/sched_setscheduler.c#L47-L52)).