### PR TITLE
fix(glob.c): fix readdirfunc declaration

### DIFF
--- a/newlib/libc/posix/glob.c
+++ b/newlib/libc/posix/glob.c
@@ -614,13 +614,7 @@ glob3(pathbuf, pathend, pathend_last, pattern, restpattern, pglob, limit)
 	int err;
 	char buf[MAXPATHLEN];
 
-	/*
-	 * The readdirfunc declaration can't be prototyped, because it is
-	 * assigned, below, to two functions which are prototyped in glob.h
-	 * and dirent.h as taking pointers to differently typed opaque
-	 * structures.
-	 */
-	struct dirent *(*readdirfunc)();
+	struct dirent *(*readdirfunc)(DIR *);
 
 	if (pathend > pathend_last)
 		return (1);


### PR DESCRIPTION
This does not compile with GCC 15 otherwise.