### PR TITLE
feat(glob.h): add GLOB_ABORTED definition

### DIFF
--- a/newlib/libc/include/glob.h
+++ b/newlib/libc/include/glob.h
@@ -81,6 +81,7 @@ typedef struct {
 #define	GLOB_NOSPACE	(-1)	/* Malloc call failed. */
 #define	GLOB_ABEND	(-2)	/* Unignored error. */
 #define	GLOB_NOMATCH	(-3)	/* No match and GLOB_NOCHECK not set. */
+#define GLOB_ABORTED GLOB_ABEND
 
 __BEGIN_DECLS
 int	glob(const char *__restrict, int, int (*)(const char *, int), 


### PR DESCRIPTION
This adds a definition for `GLOB_ABORTED` for POSIX compatibility.
See [glob.h](https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/glob.h.html) in POSIX.