### PR TITLE
fix(unistd.c): include stdio.h

### DIFF
--- a/newlib/libc/sys/hermit/unistd.c
+++ b/newlib/libc/sys/hermit/unistd.c
@@ -2,6 +2,7 @@
 #include <limits.h>
 #include <pthread.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <string.h>
 #include <sys/stat.h>
 #include <time.h>


### PR DESCRIPTION
This is required for 10a807fd3574d09ea4bd98bdb66f9eeac2e6ee9c to compile.